### PR TITLE
Fix MySQL client installation on Amazon Linux

### DIFF
--- a/src/commands/install-deps.ts
+++ b/src/commands/install-deps.ts
@@ -78,7 +78,7 @@ async function installMySQLClientAmazonLinux(): Promise<InstallResult> {
   console.log(chalk.cyan('\n📦 Installing MySQL client...'));
   const steps = [
     {
-      cmd: 'yum install -y mariadb',
+      cmd: 'yum install -y mariadb105',
       desc: 'Installing MariaDB client (MySQL compatible)',
     },
   ];


### PR DESCRIPTION
## Summary
- Fixed MySQL client installation failure on Amazon Linux EC2 instances
- Changed package name from `mariadb` to `mariadb105` which is the correct package for Amazon Linux 2/2023

## Problem
The `wfuwp install-deps` command was failing on Amazon Linux with:
```
No match for argument: mariadb
Error: Unable to find a match: mariadb
```

## Solution
Updated the package name to `mariadb105` which is available in Amazon Linux repositories.

## Test plan
- [x] Build the project successfully
- [ ] Run `sudo yum install -y mariadb105` on Amazon Linux EC2 to verify package exists
- [ ] Run `wfuwp install-deps` on Amazon Linux after publishing to verify fix

🤖 Generated with [Claude Code](https://claude.ai/code)