### PR TITLE
feat: Add EC2 local database export functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wfuwp",
-  "version": "0.12.5",
+  "version": "0.13.0",
   "description": "CLI tool for WFU WordPress management tasks",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary
Adds `--export-local-db` option to `env-migrate` command for fast prod-to-local database workflows using EC2's network speed.

• **Fast Migration**: Leverage EC2's fast connection to prod database  
• **Complete Export**: Export entire transformed local database to S3
• **Local Import**: Simple download and import to DDEV environment

## Key Features
- ✅ GTID compatibility detection for different MySQL versions
- ✅ Native MySQL client and Docker fallback support  
- ✅ Complete database export (tables, routines, triggers)
- ✅ S3 integration with metadata and usage instructions
- ✅ URL transformations applied for local development
- ✅ Comprehensive error handling and cleanup

## Usage
```bash
# On EC2 - fast migration with database export
wfuwp env-migrate prod local --export-local-db --verbose

# Download and import locally  
aws s3 cp s3://bucket/path/complete-local-database-timestamp.sql ./
ddev import-db --src=complete-local-database-timestamp.sql
ddev wp cache flush
```

## Workflow Benefits
1. **EC2 Speed**: Fast network connection to production database
2. **Ready Database**: Complete local database with proper URL transformations  
3. **S3 Distribution**: Easy sharing and backup of prepared databases
4. **Local Convenience**: Simple import to any DDEV environment

## Technical Details
- Validates option only works with `prod → local` migrations
- Requires S3 configuration for export functionality
- Uses conditional GTID options based on MySQL version detection
- Exports complete database with `--single-transaction` for consistency
- Provides clear usage instructions and S3 location info

## Test Plan
- [x] TypeScript compilation passes
- [x] Command validation works correctly  
- [x] GTID detection logic implemented
- [ ] Test complete workflow on EC2 instance
- [ ] Verify S3 upload and download process
- [ ] Test local DDEV import functionality

🤖 Generated with [Claude Code](https://claude.ai/code)