### PR TITLE
fix: resolve ESLint errors for unused variables and case declarations

### DIFF
--- a/src/commands/local.ts
+++ b/src/commands/local.ts
@@ -560,7 +560,7 @@ localCommand
 localCommand
   .command('start')
   .description('Start local development environment')
-  .action(async (options) => {
+  .action(async () => {
     try {
       console.log(chalk.bold('\n🚀 Starting Local Development Environment\n'));
 
@@ -611,7 +611,7 @@ localCommand
 localCommand
   .command('stop')
   .description('Stop local development environment')
-  .action(async (options) => {
+  .action(async () => {
     try {
       console.log(chalk.bold('\n🛑 Stopping Local Development Environment\n'));
       const manager = new DDEVManager();
@@ -650,7 +650,7 @@ localCommand
 localCommand
   .command('restart')
   .description('Restart local development environment')
-  .action(async (options) => {
+  .action(async () => {
     try {
       console.log(
         chalk.bold('\n🔄 Restarting Local Development Environment\n')

--- a/src/utils/backup-recovery.ts
+++ b/src/utils/backup-recovery.ts
@@ -331,7 +331,6 @@ export class BackupRecovery {
     }
 
     // Get site table names
-    const tablePrefix = siteId === 1 ? 'wp_' : `wp_${siteId}_`;
     const siteTableNames = await this.getSiteTableNames(environment, siteId);
 
     if (siteTableNames.length === 0) {

--- a/src/utils/error-recovery.ts
+++ b/src/utils/error-recovery.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { BackupRecovery, BackupMetadata } from './backup-recovery';
+import { BackupRecovery } from './backup-recovery';
 
 interface MigrationContext {
   sourceEnv: string;
@@ -171,7 +171,7 @@ export class ErrorRecovery {
 
     // Interactive recovery options
     if (options.interactive && !options.skipConfirmation) {
-      return await this.promptRecoveryAction(context, error);
+      return await this.promptRecoveryAction(context);
     }
 
     // Default action: rollback
@@ -270,8 +270,7 @@ export class ErrorRecovery {
   }
 
   static async promptRecoveryAction(
-    context: MigrationContext,
-    error: Error
+    context: MigrationContext
   ): Promise<RecoveryResult> {
     const readline = require('readline').createInterface({
       input: process.stdin,
@@ -335,7 +334,6 @@ export class ErrorRecovery {
     try {
       // Import utilities
       const { DatabaseOperations } = await import('./database');
-      const { Config } = await import('./config');
 
       // Check database connection
       try {

--- a/src/utils/markdown-to-wp-blocks.ts
+++ b/src/utils/markdown-to-wp-blocks.ts
@@ -168,12 +168,13 @@ export class MarkdownToWpBlocks {
           case 'em':
             return `<em>${this.processTextToken((token as any).tokens)}</em>`;
 
-          case 'link':
+          case 'link': {
             const linkToken = token as any;
             const linkText = this.processTextToken(linkToken.tokens);
             return `<a href="${linkToken.href}"${
               linkToken.title ? ` title="${linkToken.title}"` : ''
             }>${linkText}</a>`;
+          }
 
           case 'codespan':
             return `<code>${this.escapeHtml((token as any).text)}</code>`;
@@ -187,11 +188,12 @@ export class MarkdownToWpBlocks {
           case 'escape':
             return (token as any).text;
 
-          case 'image':
+          case 'image': {
             const imgToken = token as any;
             return `<img src="${imgToken.href}" alt="${imgToken.text}"${
               imgToken.title ? ` title="${imgToken.title}"` : ''
             }>`;
+          }
 
           default:
             return '';


### PR DESCRIPTION
## Summary
- Remove unused 'options' parameters from local.ts action handlers
- Remove unused 'tablePrefix' variable in backup-recovery.ts  
- Remove unused imports and parameters in error-recovery.ts
- Add block scope to case declarations in markdown-to-wp-blocks.ts

## Test plan
- [x] All ESLint errors resolved (npm run lint passes)
- [x] TypeScript compilation successful (npm run build passes)
- [x] No functional changes - only cleanup of unused code
- [x] Proper block scoping added for case declarations

🤖 Generated with [Claude Code](https://claude.ai/code)