### PR TITLE
Fix CI: build before running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,13 @@ jobs:
     
     - name: Run linter
       run: npm run lint
-    
-    - name: Run tests
-      run: npm test
-    
+
     - name: Build project
       run: npm run build
-    
+
+    - name: Run tests
+      run: npm test
+
     - name: Test CLI installation
       run: |
         npm link


### PR DESCRIPTION
`ci.yml` ran `npm test` before `npm run build`. Tests that spawn the CLI (`node ./bin/wfuwp` → `require('../dist/index.js')`) failed on clean runners because `dist/` did not exist yet — a pre-existing workflow defect (the Release workflow already builds before testing).

Reorders steps to lint → build → test → CLI install check. This unblocks the other open PRs (#26, #27, #19), which fail for this reason, not their own content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)